### PR TITLE
Added case for @observe property

### DIFF
--- a/components/XElement/src/components/XElement.astro
+++ b/components/XElement/src/components/XElement.astro
@@ -59,7 +59,13 @@ for (const name in attrs) {
 						: ``
 					}&&(${toAttributeString(data)})(e[0])).observe($);`
 					break
-
+				case 'observe':
+					listenerString += `new MutationObserver((e,o)=>${
+						opts.once
+							? `!o.disconnect()&&`
+						: ``
+					}(${toAttributeString(data)})(e[0])).observe($);`
+					break
 				default:
 					listenerString += `$.addEventListener(${toAttributeString(`"${type}"`)},${
 						opts.prevent


### PR DESCRIPTION
I have added the `@observe` property type to allow for a function to be passed in to observe any DOM changes on the element and allow for a way to interact with the changes. 
This would be handy for having web animations run when a new child node is added to the parent node, 

This would be applied as follows:
```jsx
<XElement 
   @is="ol"
   @observe={(element,{//mutation observer config options}) => for(const mutation of element){ //...do stufff here}}
 id="list"
>
  <XElement
     @is="button"
     @click={()=>list.appendChild(`<li>Added List Item</li>)}/
    > Add Item </XElement>
<XElement
   @is="button"
   @click={()=>list.removeChild(list.lastChild)}
>Remove Item </XElement>
```

In this example as the elements change the mutation observe would pick up on the child nodes being added and removed, 

Pretty certain that the code isnt right, havent tested it out at all, just wanted to get the idea down, 