### PR TITLE
Only slot non-templates when using a text fragment.

### DIFF
--- a/components/XElement/XElement.astro
+++ b/components/XElement/XElement.astro
@@ -177,7 +177,9 @@ const Template = 'template'
 ---
 <XElement {...attrs}>{
 	shadowroot == null
-		? <slot>&#8203;</slot>
+		? XElement === Fragment
+			? <slot>&#8203;</slot>
+		: null
 	: <Template shadowroot="open"><slot>&#8203;</slot></Template>
 	}</XElement>{
 	onLoadString ? 


### PR DESCRIPTION
This PR fixes an issue where Astro tries to give self-closing elements like `<input>` or `<img>` slotted content when using XElement.

```astro
<XElement @is="input" />
```

```astro
<XElement @is="img" />
```