### PR TITLE
Applied ESBuild transformation

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,19 @@
+{
+  "prettier": {
+    "semi": false,
+    "singleQuote": true,
+    "trailingComma": "es5",
+    "useTabs": true,
+    "overrides": [
+      {
+        "files": [
+          ".stackblitzrc",
+          "*.json"
+        ],
+        "options": {
+          "useTabs": false
+        }
+      }
+    ]
+  }
+}

--- a/components/XElement/.prettierrc
+++ b/components/XElement/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/components/XElement/XElement.astro
+++ b/components/XElement/XElement.astro
@@ -1,6 +1,6 @@
 ---
 import { Fragment } from 'astro/internal'
-import {createRequire} from 'node:module'
+import { createRequire } from 'node:module'
 
 const require = createRequire(import.meta.url)
 const { transformWithEsbuild } = require('vite')

--- a/components/XElement/XElement.astro
+++ b/components/XElement/XElement.astro
@@ -1,5 +1,9 @@
 ---
 import { Fragment } from 'astro/internal'
+import {createRequire} from 'node:module'
+
+const require = createRequire(import.meta.url)
+const {transformWithEsbuild} = require('vite')
 
 const {
 	'@is': tag = null,
@@ -167,6 +171,41 @@ for (const name in attrs) {
 		delete attrs['define:vars']
 	}
 }
+
+const ParseLoadString: string = `
+	(async function($$,$){$=this;$$=(await import($$.src)).default;${
+			defineVarsString ?? ``
+		}${
+			listenerString ?? ``
+		}${
+			listenerOfOnce ?? ``
+		}}).call(this.previousSibling,this.remove()||this)
+`
+/** Transforms the JS/TS input using ESBuild */
+const transformer = async (code:string):Promise<string>=> (await transformWithEsbuild(code,`xelement.ts`,{minify: true})).code 
+
+/** Create a hashmap to store the transformed code */
+const hash = Object.create(null)
+
+/** Return transformed code, remembering previously transformed code. */
+const memo = async (code: string) => {
+  //NoOp if the code is undefined, 
+  if (code === undefined) return
+  // if the hashmap has the transformed code for this code, return it
+  if (code in hash) return hash[code]
+
+  // otherwise, the transform code and assign it to the hashmap
+  hash[code] = await transformer(code)
+
+  // and return the transformed code
+  return hash[code]
+}
+
+const onLoadString: string = (
+    listenerString || listenerOfOnce
+        ? (await memo(LoadString))
+    : null
+)
 
 const onLoadString: string = (
 	listenerString || listenerOfOnce

--- a/components/XElement/XElement.astro
+++ b/components/XElement/XElement.astro
@@ -37,14 +37,14 @@ const serialize = (value: any) => {
 			return (
 				Array.isArray(value)
 					? `[${
-						Object.values(value)
+						Object.values(value).map(serialize)
 					}]`
 				: value instanceof RegExp
 					? String(value)
 				: `{${
-					Object.keys(value).map(name => {
-						`${JSON.stringify(name)}:${serialize(value)}`
-					})
+					Object.keys(value).map(
+						name => `${JSON.stringify(name)}:${serialize(value[name])}`
+					)
 				}}`
 			)
 
@@ -172,16 +172,6 @@ for (const name in attrs) {
 	}
 }
 
-const Payload: string = `
-	(async function($$,$){$=this;$$=(await import($$.src)).default;${
-			defineVarsString ?? ``
-		}${
-			listenerString ?? ``
-		}${
-			listenerOfOnce ?? ``
-		}}).call(this.previousSibling,this.remove()||this)
-`
-
 /** Transforms the JS/TS input using ESBuild */
 const transformer = async (code: string): Promise<string> => await transformWithEsbuild(code, 'xelement.ts', { minify: true }).then(result => result.code)
 
@@ -190,40 +180,45 @@ const hash = Object.create(null)
 
 /** Return transformed code, remembering previously transformed code. */
 const memo = async (code: string) => {
-  //NoOp if the code is undefined, 
-  if (code === undefined) return
-  // if the hashmap has the transformed code for this code, return it
-  if (code in hash) return hash[code]
+	// if the hashmap has the transformed code for this code, return it
+	if (code in hash) return hash[code]
 
-  // otherwise, the transform code and assign it to the hashmap
-  hash[code] = await transformer(code)
+	// otherwise, the transform code and assign it to the hashmap
+	hash[code] = await transformer(code)
 
-  // and return the transformed code
-  return hash[code]
+	// and return the transformed code
+	return hash[code]
 }
 
 const onLoadString: string = (
 	listenerString || listenerOfOnce
-		? await memo(Payload)
-	: null
+		? await memo(
+			`(async function($$,$){$=this;$$=(await import($$.src)).default;${
+				defineVarsString ?? ''
+			}${
+				listenerString ?? ''
+			}${
+				listenerOfOnce ?? ''
+			}}).call(this.previousSibling,this.remove()||this)`
+		)
+	: ''
 )
-
 
 /** Matching ShadowRoot attribute. */
 let shadowRoot = Object.keys(attrs).find(name => /^shadowroot$/i.test(name))
 
 if (shadowRoot) {
-  /** Formatted ShadowRoot attribute value */
-  let value = attrs[shadowRoot]
+	/** Formatted ShadowRoot attribute value */
+	let value = attrs[shadowRoot]
 
-  // format the ShadowRoot attribute value
-  value = typeof value === 'string' ? value : value ? 'open' : 'closed'
+	// format the ShadowRoot attribute value
+	value = typeof value === 'string' ? value : value ? 'open' : 'closed'
 
-  // remove it from the attributes sent to the main element
-  delete attrs[shadowRoot]
+	// remove it from the attributes sent to the main element
+	delete attrs[shadowRoot]
 
-  // update the shadowRoot attribute value
-  shadowRoot = value
+	// update the shadowRoot attribute value
+	shadowRoot = value
 }
 
 const AstroFragment = Fragment as unknown as string

--- a/components/XElement/XElement.astro
+++ b/components/XElement/XElement.astro
@@ -202,9 +202,9 @@ const memo = async (code: string) => {
 }
 
 const onLoadString: string = (
-    listenerString || listenerOfOnce
-        ? (await memo(Payload))
-    : null
+	listenerString || listenerOfOnce
+		? (await memo(Payload))
+	: null
 )
 
 const onLoadString: string = (

--- a/components/XElement/XElement.astro
+++ b/components/XElement/XElement.astro
@@ -204,7 +204,7 @@ const memo = async (code: string) => {
 
 const onLoadString: string = (
 	listenerString || listenerOfOnce
-		? (await memo(Payload))
+		? await memo(Payload)
 	: null
 )
 

--- a/components/XElement/XElement.astro
+++ b/components/XElement/XElement.astro
@@ -208,17 +208,6 @@ const onLoadString: string = (
 	: null
 )
 
-const onLoadString: string = (
-	listenerString || listenerOfOnce
-		? `(async function($$,$){$=this;$$=(await import($$.src)).default;${
-			defineVarsString ?? ``
-		}${
-			listenerString ?? ``
-		}${
-			listenerOfOnce ?? ``
-		}}).call(this.previousSibling,this.remove()||this)`
-	: null
-)
 
 /** Matching ShadowRoot attribute. */
 let shadowRoot = Object.keys(attrs).find(name => /^shadowroot$/i.test(name))

--- a/components/XElement/XElement.astro
+++ b/components/XElement/XElement.astro
@@ -172,7 +172,7 @@ for (const name in attrs) {
 	}
 }
 
-const ParseLoadString: string = `
+const Payload: string = `
 	(async function($$,$){$=this;$$=(await import($$.src)).default;${
 			defineVarsString ?? ``
 		}${
@@ -203,7 +203,7 @@ const memo = async (code: string) => {
 
 const onLoadString: string = (
     listenerString || listenerOfOnce
-        ? (await memo(LoadString))
+        ? (await memo(Payload))
     : null
 )
 

--- a/components/XElement/XElement.astro
+++ b/components/XElement/XElement.astro
@@ -182,7 +182,7 @@ const Payload: string = `
 		}}).call(this.previousSibling,this.remove()||this)
 `
 /** Transforms the JS/TS input using ESBuild */
-const transformer = async (code:string):Promise<string>=> (await transformWithEsbuild(code,`xelement.ts`,{minify: true})).code 
+const transformer = async (code: string): Promise<string> => await transformWithEsbuild(code, 'xelement.ts', { minify: true }).then(result => result.code)
 
 /** Create a hashmap to store the transformed code */
 const hash = Object.create(null)

--- a/components/XElement/XElement.astro
+++ b/components/XElement/XElement.astro
@@ -181,6 +181,7 @@ const Payload: string = `
 			listenerOfOnce ?? ``
 		}}).call(this.previousSibling,this.remove()||this)
 `
+
 /** Transforms the JS/TS input using ESBuild */
 const transformer = async (code: string): Promise<string> => await transformWithEsbuild(code, 'xelement.ts', { minify: true }).then(result => result.code)
 

--- a/components/XElement/XElement.astro
+++ b/components/XElement/XElement.astro
@@ -3,7 +3,7 @@ import { Fragment } from 'astro/internal'
 import {createRequire} from 'node:module'
 
 const require = createRequire(import.meta.url)
-const {transformWithEsbuild} = require('vite')
+const { transformWithEsbuild } = require('vite')
 
 const {
 	'@is': tag = null,


### PR DESCRIPTION
This PR applies ESBuild to XElement and introduces a transformation step, where the JS or TS entered into the `Payload` is now transformed and minified.

The end result is a cleaner, transformed and smaller payload pushed through, resulting in better performance in build time and FCP,

This to iterate allows for Typescript to now be used within the `<XElement>` handlers, 🥳

I would like to pay my thanks to @okikio for his epic contribution in helping to guide this into creation, and for @jonathantneal  for helping to make it safe and stable to use. 

Thank you guys, you're both legends,