### PR TITLE
Added in-line styling for XElement

### DIFF
--- a/components/XElement/XElement.astro
+++ b/components/XElement/XElement.astro
@@ -24,6 +24,8 @@ let listenerOfOnce: string = ''
 
 let defineVarsString: string = ''
 
+let defineStyleString: string = ''
+
 /** Returns the null-safe type of value. */
 const typeOf = (value: any) => value === null ? 'null' : typeof value
 
@@ -170,6 +172,18 @@ for (const name in attrs) {
 
 		delete attrs['define:vars']
 	}
+
+	if(name.includes('define:style')){
+		const data = attrs['define:style']
+		if(typeOf(data) === 'object') {
+			defineStyleString = `this.style = ${
+				Object.entries(data).map(
+					([ name, value ]) => `${
+						serialize(value)}`
+				)};`
+		}
+		delete attrs['define:style']
+	}
 }
 
 /** Transforms the JS/TS input using ESBuild */
@@ -191,9 +205,11 @@ const memo = async (code: string) => {
 }
 
 const onLoadString: string = (
-	listenerString || listenerOfOnce
+	listenerString || listenerOfOnce || defineStyleString
 		? await memo(
 			`(async function($$,$){$=this;$$=(await import($$.src)).default;${
+				defineStyleString ?? ''
+			}${	
 				defineVarsString ?? ''
 			}${
 				listenerString ?? ''


### PR DESCRIPTION
Added in-line styling options for XElement that eliminates the need of manually setting the style from JS.

Create a templated style - with variables if needed, then pass it into define:style (in the same manner as define:vars works)

eg:

```
---
const Height = Astro.props.Height;
const Color = Astro.props.Color;
const divStyle = `
    background-color: ${Color};
    height: ${Height};
    width: 100%;
`;
---

<XElement define:style={{divStyle}} />

```