### PR TITLE
Sticky header and edit link ready for page renames

### DIFF
--- a/www/xelement/src/components/Header/Header.astro
+++ b/www/xelement/src/components/Header/Header.astro
@@ -3,7 +3,7 @@
   import StorkSearch from '../Stork/StorkSearch.astro'
   import {Icon} from 'astro-icon'
 ---
-<header class="navbar navbar_header">
+<header class="navbar navbar_header sticky-head">
     <div class="navbar_logo">
         <Icon name="astro-ui"/>
     </div>

--- a/www/xelement/src/layouts/DocsLayout.astro
+++ b/www/xelement/src/layouts/DocsLayout.astro
@@ -21,6 +21,8 @@ const intersectionFn = (element)=>{
     const headings =[...document.querySelectorAll('.js-documentation > h1, h2, h3, h4, h5 ')]
     headings.forEach(heading=>observer.observe(heading))
 }
+
+const githubEditUrl = `https://github.com/aFuzzyBear/astro-ui/blob/main/docs/XElement${Astro.request.url.pathname.replace(/\/docs/, '')}.md`;
 ---
     <BaseLayout 
         PageMeta={{page_title,page_description}}
@@ -33,7 +35,7 @@ const intersectionFn = (element)=>{
     >
         <Header class="navbar navbar__header"/>
         <main class="layout">
-            <aside class=".grid-left .grid-sidebar sticky-div">
+            <aside class=".grid-left .grid-sidebar sticky-leftbar">
                 <div class="sidebar__feature">
                     <h3>
                         API
@@ -80,13 +82,35 @@ const intersectionFn = (element)=>{
                 {html}
             </Article>
             <div class="break__row"></div>
-            <aside class="rightbar .grid-right sticky-div">
+            <aside class="rightbar .grid-right sticky-rightbar">
                 <div class="">
                     <h1>
                         Something
                     </h1>
                     <TableOfContents headers={headers}/>
                 </div>
+                <div class="edit-on-github">
+                    <a href={githubEditUrl} target="_blank">
+                        <svg
+                            aria-hidden="true"
+                            focusable="false"
+                            data-prefix="fas"
+                            data-icon="pen"
+                            class="svg-inline--fa fa-pen fa-w-16"
+                            role="img"
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 512 512"
+                            height="1em"
+                            width="1em"
+                        >
+                            <path
+                                fill="currentColor"
+                                d="M290.74 93.24l128.02 128.02-277.99 277.99-114.14 12.6C11.35 513.54-1.56 500.62.14 485.34l12.7-114.22 277.9-277.88zm207.2-19.06l-60.11-60.11c-18.75-18.75-49.16-18.75-67.91 0l-56.55 56.55 128.02 128.02 56.55-56.55c18.75-18.76 18.75-49.16 0-67.91z"
+                            ></path>
+                        </svg>
+                        <span>Edit this page</span>
+                    </a>
+	            </div>
             </aside>
         </main>
         <div class="break-row"></div>

--- a/www/xelement/src/styles/docsLayout.scss
+++ b/www/xelement/src/styles/docsLayout.scss
@@ -15,12 +15,27 @@ main.layout{
     ***Sticky Right Sidebar***
 */
 
-.sticky-div {
+.sticky-head {
     position:sticky;
     top: 0;
+    @apply bg-[color:var(--theme-bg-color)]
+}
+.sticky-rightbar {
+    position:sticky;
+    top: 50px;
+}
+
+.sticky-leftbar {
+    position:sticky;
+    top: 120px;
 }
 
 .heading__icon {
     margin-right: 0.25em;
+ }
+
+ .edit-on-github {
+     border-top: 2px solid;
+     padding-top: 0.5em;
  }
  

--- a/www/xelement/src/styles/docsLayout.scss
+++ b/www/xelement/src/styles/docsLayout.scss
@@ -22,7 +22,7 @@ main.layout{
 }
 .sticky-rightbar {
     position:sticky;
-    top: 50px;
+    top: 120px;
 }
 
 .sticky-leftbar {

--- a/www/xelement/src/styles/docsLayout.scss
+++ b/www/xelement/src/styles/docsLayout.scss
@@ -23,6 +23,7 @@ main.layout{
 .sticky-rightbar {
     position:sticky;
     top: 120px;
+    padding-right: 1em;
 }
 
 .sticky-leftbar {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2429,11 +2429,6 @@ astro-stylesheet@^3.0.0:
   resolved "https://registry.yarnpkg.com/astro-stylesheet/-/astro-stylesheet-3.0.0.tgz#8c2e0dc992da8914d6188f4a943134d71973d92d"
   integrity sha512-IZ5ZVslH1aZHhwRa7hLZRjBSwVOQVmNpQQZXe3ikvAUYTBwUir4wf9q15hh/ngsXLwws4fbOo99ysEwtl/PQ4A==
 
-astro-xelement@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/astro-xelement/-/astro-xelement-3.1.1.tgz#88a07869442c5e80145164050eb0951c921af829"
-  integrity sha512-S5Ldse+ebDJzJH69Dpi2kHRZnAA/26+mucq/VysUD72W4iOVRAtcqrgQtBPrU34MHJo1Beg/t3Ha/RSA7OJWiw==
-
 astro@^0.20.7, astro@^0.20.9:
   version "0.20.12"
   resolved "https://registry.yarnpkg.com/astro/-/astro-0.20.12.tgz#24f18e9fed95294b77606de3891d40d2852be1bd"
@@ -2561,7 +2556,7 @@ astro@^0.22.1:
     yargs-parser "^21.0.0"
     zod "^3.8.1"
 
-astro@^0.22.20:
+astro@^0.22.17, astro@^0.22.20:
   version "0.22.20"
   resolved "https://registry.yarnpkg.com/astro/-/astro-0.22.20.tgz#d7ebe747255e5861a8de408ac544786a90226485"
   integrity sha512-2WaISKXWi8wGzHMM20YSyMLDNI+zKvOO4y/Z8BI7HMSomtGSXkBWdryWjkvHlH9VjW3VGYjpa5pqZ2k72o+aAw==
@@ -2659,66 +2654,6 @@ astro@latest:
     mime "^3.0.0"
     morphdom "^2.6.1"
     node-fetch "^3.0.0"
-    parse5 "^6.0.1"
-    path-to-regexp "^6.2.0"
-    postcss "^8.3.8"
-    prismjs "^1.25.0"
-    rehype-slug "^5.0.0"
-    resolve "^1.20.0"
-    rollup "^2.57.0"
-    sass "^1.43.4"
-    semver "^7.3.5"
-    send "^0.17.1"
-    shiki "^0.9.10"
-    shorthash "^0.0.2"
-    slash "^4.0.0"
-    sourcemap-codec "^1.4.8"
-    srcset-parse "^1.1.0"
-    string-width "^5.0.0"
-    strip-ansi "^7.0.1"
-    supports-esm "^1.0.0"
-    tsconfig-resolver "^3.0.1"
-    vite "~2.6.10"
-    yargs-parser "^21.0.0"
-    zod "^3.8.1"
-
-astro@^0.22.20:
-  version "0.22.20"
-  resolved "https://registry.yarnpkg.com/astro/-/astro-0.22.20.tgz#d7ebe747255e5861a8de408ac544786a90226485"
-  integrity sha512-2WaISKXWi8wGzHMM20YSyMLDNI+zKvOO4y/Z8BI7HMSomtGSXkBWdryWjkvHlH9VjW3VGYjpa5pqZ2k72o+aAw==
-  dependencies:
-    "@astrojs/compiler" "^0.9.2"
-    "@astrojs/language-server" "^0.8.6"
-    "@astrojs/markdown-remark" "^0.6.0"
-    "@astrojs/prism" "0.4.0"
-    "@astrojs/renderer-preact" "^0.4.0"
-    "@astrojs/renderer-react" "0.4.1"
-    "@astrojs/renderer-svelte" "0.3.1"
-    "@astrojs/renderer-vue" "0.3.0"
-    "@astropub/webapi" "^0.10.1"
-    "@babel/core" "^7.15.8"
-    "@babel/traverse" "^7.15.4"
-    "@proload/core" "^0.2.1"
-    "@proload/plugin-tsm" "^0.1.0"
-    "@types/babel__core" "^7.1.15"
-    "@web/parse5-utils" "^1.3.0"
-    astring "^1.7.5"
-    ci-info "^3.2.0"
-    common-ancestor-path "^1.0.1"
-    connect "^3.7.0"
-    eol "^0.9.1"
-    es-module-lexer "^0.9.3"
-    esbuild "0.13.7"
-    estree-util-value-to-estree "^1.2.0"
-    estree-walker "^3.0.0"
-    fast-glob "^3.2.7"
-    fast-xml-parser "^4.0.0-beta.3"
-    html-entities "^2.3.2"
-    htmlparser2 "^7.1.2"
-    kleur "^4.1.4"
-    magic-string "^0.25.7"
-    mime "^3.0.0"
-    morphdom "^2.6.1"
     parse5 "^6.0.1"
     path-to-regexp "^6.2.0"
     postcss "^8.3.8"


### PR DESCRIPTION
Sticky header AND sidebars, all at various heights of stickiness to look good. (NB: header needed a background colour of theme body colour, and I believe that works consistently across themes, too.)

ALSO, while not *perfect*, the edit link is CORRECT once page names are changed to lowercase only. I think this is the best solution to this problem, since links on GitHub appear to be case sensitive, whereas path urls are all lower case.