### PR TITLE
[Stylesheet] use new directive to escape html

### DIFF
--- a/components/Stylesheet/Stylesheet.astro
+++ b/components/Stylesheet/Stylesheet.astro
@@ -171,6 +171,6 @@ const populateSanitizer = async() =>{
 
 ---
     <!-- Stylesheets -->
-    {linkCSS}
-    {await populateSanitizer()}
+    <Fragment set:html={linkCSS} />
+    <Fragment set:html={await populateSanitizer()} />
     <!-- End of Stylesheets -->


### PR DESCRIPTION
- use new set:html directive to escape html in expressions
- fixes warning when using astro@0.23
- I am unsure if this breaks old versions
- let me know if this is the wrong branch
### warning logged to console after updating to astro@0.23
```sh
The next minor version of Astro will automatically escape all
expression content. Please use the `set:html` directive.
```