### PR TITLE
Add async attribute to manager and stylesheet

### DIFF
--- a/components/Stylesheet/Manager.astro
+++ b/components/Stylesheet/Manager.astro
@@ -10,7 +10,7 @@ interface Props extends StylesheetProps{
     critical?:boolean
 }
 
-const {href,media,alternative,cors,preload,title,list,sanitizer,OProps, critical} = Astro.props as Props
+const {href,media,alternative,cors,preload,async,title,list,sanitizer,OProps, critical} = Astro.props as Props
 
 ---
     <!-- Managed Stylesheets -->
@@ -33,7 +33,7 @@ const {href,media,alternative,cors,preload,title,list,sanitizer,OProps, critical
     }
     {
         href &&
-        <StylesheetLink  href={href} media={media} alternative={alternative} cors={cors} preload={preload} title={title}/>
+        <StylesheetLink  href={href} media={media} alternative={alternative} cors={cors} preload={preload} async={async} title={title}/>
     }
     {
          list &&

--- a/components/Stylesheet/README.md
+++ b/components/Stylesheet/README.md
@@ -28,6 +28,7 @@ import Manager  from 'astro-stylesheet/Manager'
   <!-- Manage individual stylesheets -->
   <Manager href="styles/main.css" critical/>
   <Manager href="styles/print.css" media="print" preload/>
+  <Manager href="styles/print.css" async/>
   <Manager href="styles/alternative.css" alternative title="An Alternative Stylesheet"/>
   <!-- Batch Manage the Stylesheets -->
   <Manager list={
@@ -84,6 +85,7 @@ import Stylesheet  from 'astro-stylesheet/Stylesheet'
   <!-- Manage individual stylesheets -->
   <Stylesheet href="styles/main.css" critical/>
   <Stylesheet href="styles/print.css" media="print" preload/>
+  <Stylesheet href="styles/other.css" async/>
   <Stylesheet href="styles/alternative.css" alternative title="An Alternative Stylesheet"/>
   <!-- Batch Manage the Stylesheets -->
   <Stylesheet list={
@@ -109,6 +111,7 @@ interface StylesheetProps{
     href?:string,
     media?:string,
     preload?:boolean,
+    async?:boolean,
     title?:string,
     alternative?:boolean,
     cors?: 'anonymous' | 'use-credentials',
@@ -145,6 +148,14 @@ This `preload` attribute allows you to stipulate if that particular stylesheet s
 
 ```astro
 <Stylesheet ... preload />
+```
+
+### `preload?`
+
+This `async` attribute allows you download a stylesheet asynchronously with `media="print" onload="this.media='all'"`
+
+```astro
+<Stylesheet ... async />
 ```
 
 ### `alternative?`

--- a/components/Stylesheet/Stylesheet.astro
+++ b/components/Stylesheet/Stylesheet.astro
@@ -6,6 +6,7 @@ interface list{
   href?:string,
   media?:string,
   preload?:boolean,
+  async?:boolean,
   title?:string,
   alternative?:boolean,
   cors?: 'anonymous' | 'use-credentials'
@@ -17,7 +18,7 @@ interface Props extends list{
   list?:list[],
 }
 
-let {href,media, preload, title, alternative, cors, list} = Astro.props as Props
+let {href,media, preload, async, title, alternative, cors, list} = Astro.props as Props
 
 let styleList = []
 
@@ -42,7 +43,8 @@ if(href && !list) {
   styleList.push({
     href,
     media,
-    preload,
+    preload: async ? false : preload,
+    async,
     alternative,
     cors,
     title
@@ -62,6 +64,7 @@ if(list && href){
         href:path,
         media,
         preload,
+        async,
         title,
         alternative,
         cors
@@ -75,7 +78,8 @@ if(list && href){
               ? "alternative stylesheet"
               : "stylesheet"
             }
-            media = { media ?? null }
+            media = { async ? 'print' : media ?? null }
+            onload = { async ? 'this.media="all"' : null }
             title = { title && alternative ? title : null }
             as    = { preload && "style" }
             type  = "text/css"

--- a/components/Stylesheet/package.json
+++ b/components/Stylesheet/package.json
@@ -10,7 +10,7 @@
   ],
   "description": "Astro StyleSheet <link> Component, This single Component provides the interface to apply a single stylesheet or many stylesheets in one place, have it also apply relevant sanitize.css scripts through use of a single Prop",
   "license": "MIT",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "homepage": "https://github.com/aFuzzyBear/astro-ui/tree/main/components/Stylesheet",
   "bugs": {
     "url": "https://github.com/aFuzzyBear/astro-ui/tree/main/components/Stylesheet/issues"


### PR DESCRIPTION
Adds ability to set stylesheet to be loaded asynchronously.

Uses `media="print" onload="this.media='all'" `